### PR TITLE
Add Binance DOM interpreter app with ticker choice

### DIFF
--- a/binance-dom/.gitignore
+++ b/binance-dom/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.pyc
+.streamlit/secrets.toml

--- a/binance-dom/README.md
+++ b/binance-dom/README.md
@@ -1,0 +1,51 @@
+# Binance DOM Interpreter
+
+A Streamlit app that pulls live **depth-of-market (order book)** data from the
+Binance public API for any ticker you choose and interprets it: spread,
+imbalance, depth chart, buy/sell walls, and market-order slippage estimates.
+
+## Features
+
+- **Ticker choice** — searchable dropdown of every trading spot symbol,
+  sorted by 24h quote volume, filterable by quote asset (USDT, FDUSD, USDC,
+  BTC, ETH, ...).
+- **Order book ladder** — bids/asks side by side with visual depth bars and
+  cumulative size.
+- **Depth chart** — cumulative quote depth vs distance from mid price.
+- **Interpretation panel** — plain-English read of spread, ±0.5%/±2% depth
+  imbalance, and the largest walls (potential support/resistance).
+- **Walls detection** — levels whose size exceeds a configurable multiple of
+  the median level size.
+- **Market impact estimator** — walks the book to compute VWAP and slippage
+  for a hypothetical market buy/sell of a given quote size.
+- **Auto-refresh** — optional live polling every 2–60 s.
+- **Endpoint selector** — defaults to `data-api.binance.vision` (Binance.com
+  market data, no key needed, works where `api.binance.com` is geo-blocked);
+  Binance.US also available.
+
+## Quick start
+
+```bash
+cd binance-dom
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+streamlit run app.py
+```
+
+Then open http://localhost:8501.
+
+## Project layout
+
+| File | Purpose |
+| --- | --- |
+| `binance_client.py` | REST client for Binance public market data (no API key needed) |
+| `dom_analysis.py` | Pure interpretation functions: spread, imbalance, walls, slippage |
+| `app.py` | Streamlit UI |
+
+## Notes
+
+- All endpoints used are public market data; no Binance account or API key is
+  required.
+- The book snapshot is REST-based (`GET /api/v3/depth`), so it reflects the
+  moment of the fetch. Enable auto-refresh for a near-live view.
+- This is an analytics tool, not financial advice.

--- a/binance-dom/app.py
+++ b/binance-dom/app.py
@@ -83,7 +83,7 @@ def main() -> None:
         st.header("Live updates")
         auto = st.toggle("Auto-refresh", value=False)
         interval = st.slider("Interval (s)", 2, 60, 5, disabled=not auto)
-        if st.button("🔄 Refresh now", use_container_width=True):
+        if st.button("🔄 Refresh now", width="stretch"):
             st.rerun()
 
     if auto:
@@ -129,7 +129,7 @@ def main() -> None:
         height=380, margin=dict(l=10, r=10, t=10, b=10),
         legend=dict(orientation="h", y=1.1),
     )
-    st.plotly_chart(fig, use_container_width=True)
+    st.plotly_chart(fig, width="stretch")
 
     st.markdown("### Order book ladder")
     bid_col, ask_col = st.columns(2)
@@ -140,7 +140,7 @@ def main() -> None:
                 {"Price": "{:,.6g}", "Qty": "{:,.4f}",
                  "Size (quote)": "{:,.0f}", "Cumulative (quote)": "{:,.0f}"}
             ).bar(subset=["Size (quote)"], color="#26a69a"),
-            use_container_width=True, height=420,
+            width="stretch", height=420,
         )
     with ask_col:
         st.markdown("**Asks** 🔴")
@@ -149,7 +149,7 @@ def main() -> None:
                 {"Price": "{:,.6g}", "Qty": "{:,.4f}",
                  "Size (quote)": "{:,.0f}", "Cumulative (quote)": "{:,.0f}"}
             ).bar(subset=["Size (quote)"], color="#ef5350"),
-            use_container_width=True, height=420,
+            width="stretch", height=420,
         )
 
     st.markdown("### Walls & market impact")
@@ -159,13 +159,13 @@ def main() -> None:
         bw = da.detect_walls(book.bids, wall_mult)
         st.dataframe(bw.style.format({"price": "{:,.6g}", "qty": "{:,.4f}",
                                       "quote": "{:,.0f}", "size_vs_median": "{:.1f}×"}),
-                     use_container_width=True) if not bw.empty else st.info("None detected.")
+                     width="stretch") if not bw.empty else st.info("None detected.")
     with w2:
         st.markdown("**Ask walls** (potential resistance)")
         aw = da.detect_walls(book.asks, wall_mult)
         st.dataframe(aw.style.format({"price": "{:,.6g}", "qty": "{:,.4f}",
                                       "quote": "{:,.0f}", "size_vs_median": "{:.1f}×"}),
-                     use_container_width=True) if not aw.empty else st.info("None detected.")
+                     width="stretch") if not aw.empty else st.info("None detected.")
     with w3:
         st.markdown(f"**Market order impact** (${order_size:,.0f})")
         buy = da.estimate_market_order(book.asks, order_size)
@@ -177,7 +177,7 @@ def main() -> None:
              "Filled": f"{sell['fill_pct']:.1f}%"},
         ])
         st.dataframe(impact.style.format({"VWAP": "{:,.6g}", "Slippage (bps)": "{:.2f}"}),
-                     use_container_width=True, hide_index=True)
+                     width="stretch", hide_index=True)
 
     with st.expander("Raw order book data"):
         st.json({

--- a/binance-dom/app.py
+++ b/binance-dom/app.py
@@ -1,0 +1,192 @@
+"""Binance DOM Interpreter — Streamlit app.
+
+Run with:  streamlit run app.py
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import plotly.graph_objects as go
+import streamlit as st
+from streamlit_autorefresh import st_autorefresh
+
+import dom_analysis as da
+from binance_client import BASE_URLS, DEPTH_LIMITS, BinanceAPIError, BinanceClient
+
+QUOTE_ASSETS = ["USDT", "FDUSD", "USDC", "TUSD", "BTC", "ETH", "BNB", "EUR", "TRY"]
+POPULAR = ["BTCUSDT", "ETHUSDT", "SOLUSDT", "BNBUSDT", "XRPUSDT", "DOGEUSDT"]
+
+st.set_page_config(page_title="Binance DOM Interpreter", page_icon="📖", layout="wide")
+
+
+@st.cache_resource
+def get_client(base_url: str) -> BinanceClient:
+    return BinanceClient(base_url)
+
+
+@st.cache_data(ttl=300, show_spinner=False)
+def load_symbols(base_url: str, quote_assets: tuple[str, ...]) -> list[str]:
+    return get_client(base_url).get_symbols(quote_assets)
+
+
+@st.cache_data(ttl=60, show_spinner=False)
+def load_volume_rank(base_url: str, quote_assets: tuple[str, ...]) -> dict[str, float]:
+    tickers = get_client(base_url).get_24h_tickers(quote_assets)
+    return {t["symbol"]: float(t["quoteVolume"]) for t in tickers}
+
+
+def ladder_frame(levels, n: int, reverse: bool) -> pd.DataFrame:
+    df = da.to_frame(levels).head(n)
+    df["cum_quote"] = df["quote"].cumsum()
+    df = df[["price", "qty", "quote", "cum_quote"]]
+    df.columns = ["Price", "Qty", "Size (quote)", "Cumulative (quote)"]
+    return df.iloc[::-1] if reverse else df
+
+
+def main() -> None:
+    st.title("📖 Binance DOM Interpreter")
+    st.caption("Live depth-of-market (order book) analytics from Binance public market data.")
+
+    with st.sidebar:
+        st.header("Data source")
+        base_label = st.selectbox("API endpoint", list(BASE_URLS), index=0)
+        base_url = BASE_URLS[base_label]
+        quote_assets = tuple(
+            st.multiselect("Quote assets", QUOTE_ASSETS, default=["USDT"])
+        ) or ("USDT",)
+
+        st.header("Ticker")
+        try:
+            symbols = load_symbols(base_url, quote_assets)
+        except BinanceAPIError as e:
+            st.error(f"Could not load symbols: {e}")
+            st.stop()
+        volume = load_volume_rank(base_url, quote_assets)
+        symbols = sorted(symbols, key=lambda s: volume.get(s, 0.0), reverse=True)
+        default_idx = next(
+            (i for i, s in enumerate(symbols) if s == "BTCUSDT"),
+            next((i for i, s in enumerate(symbols) if s in POPULAR), 0),
+        )
+        symbol = st.selectbox(
+            "Symbol (sorted by 24h quote volume)", symbols, index=default_idx
+        )
+        limit = st.selectbox("Book depth (levels)", DEPTH_LIMITS, index=4)
+
+        st.header("Analysis")
+        wall_mult = st.slider("Wall threshold (× median level)", 2.0, 20.0, 5.0, 0.5)
+        order_size = st.number_input(
+            "Hypothetical market order size (quote)", min_value=100.0,
+            value=50_000.0, step=10_000.0, format="%.0f",
+        )
+        ladder_rows = st.slider("Ladder rows shown", 5, 40, 15)
+
+        st.header("Live updates")
+        auto = st.toggle("Auto-refresh", value=False)
+        interval = st.slider("Interval (s)", 2, 60, 5, disabled=not auto)
+        if st.button("🔄 Refresh now", use_container_width=True):
+            st.rerun()
+
+    if auto:
+        st_autorefresh(interval=interval * 1000, key="dom-refresh")
+
+    client = get_client(base_url)
+    try:
+        book = client.get_order_book(symbol, limit)
+        last_price = client.get_price(symbol)
+    except BinanceAPIError as e:
+        st.error(str(e))
+        st.stop()
+
+    m = da.spread_metrics(book)
+    band1 = da.depth_within_pct(book, 1.0)
+    top10 = da.top_n_imbalance(book, 10)
+
+    st.subheader(f"{symbol} — order book snapshot")
+    c1, c2, c3, c4, c5 = st.columns(5)
+    c1.metric("Last price", f"{last_price:,.6g}")
+    c2.metric("Mid price", f"{m['mid']:,.6g}")
+    c3.metric("Spread", f"{m['spread_bps']:.2f} bps")
+    c4.metric("Imbalance ±1%", f"{band1['imbalance']:+.2f}")
+    c5.metric("Top-10 imbalance", f"{top10:+.2f}")
+
+    st.markdown("### Interpretation")
+    for line in da.interpret(book, wall_mult):
+        st.markdown(f"- {line}")
+
+    st.markdown("### Depth chart")
+    depth = da.cumulative_depth(book)
+    fig = go.Figure()
+    for side, color in (("Bids", "#26a69a"), ("Asks", "#ef5350")):
+        d = depth[depth["side"] == side]
+        fig.add_trace(go.Scatter(
+            x=d["pct_from_mid"], y=d["cum_quote"], name=side,
+            fill="tozeroy", line=dict(color=color, width=2),
+            hovertemplate="%{x:.2f}% from mid<br>$%{y:,.0f} cumulative<extra>%{fullData.name}</extra>",
+        ))
+    fig.update_layout(
+        xaxis_title="Distance from mid price (%)",
+        yaxis_title="Cumulative depth (quote currency)",
+        height=380, margin=dict(l=10, r=10, t=10, b=10),
+        legend=dict(orientation="h", y=1.1),
+    )
+    st.plotly_chart(fig, use_container_width=True)
+
+    st.markdown("### Order book ladder")
+    bid_col, ask_col = st.columns(2)
+    with bid_col:
+        st.markdown("**Bids** 🟢")
+        st.dataframe(
+            ladder_frame(book.bids, ladder_rows, reverse=True).style.format(
+                {"Price": "{:,.6g}", "Qty": "{:,.4f}",
+                 "Size (quote)": "{:,.0f}", "Cumulative (quote)": "{:,.0f}"}
+            ).bar(subset=["Size (quote)"], color="#26a69a"),
+            use_container_width=True, height=420,
+        )
+    with ask_col:
+        st.markdown("**Asks** 🔴")
+        st.dataframe(
+            ladder_frame(book.asks, ladder_rows, reverse=False).style.format(
+                {"Price": "{:,.6g}", "Qty": "{:,.4f}",
+                 "Size (quote)": "{:,.0f}", "Cumulative (quote)": "{:,.0f}"}
+            ).bar(subset=["Size (quote)"], color="#ef5350"),
+            use_container_width=True, height=420,
+        )
+
+    st.markdown("### Walls & market impact")
+    w1, w2, w3 = st.columns(3)
+    with w1:
+        st.markdown("**Bid walls** (potential support)")
+        bw = da.detect_walls(book.bids, wall_mult)
+        st.dataframe(bw.style.format({"price": "{:,.6g}", "qty": "{:,.4f}",
+                                      "quote": "{:,.0f}", "size_vs_median": "{:.1f}×"}),
+                     use_container_width=True) if not bw.empty else st.info("None detected.")
+    with w2:
+        st.markdown("**Ask walls** (potential resistance)")
+        aw = da.detect_walls(book.asks, wall_mult)
+        st.dataframe(aw.style.format({"price": "{:,.6g}", "qty": "{:,.4f}",
+                                      "quote": "{:,.0f}", "size_vs_median": "{:.1f}×"}),
+                     use_container_width=True) if not aw.empty else st.info("None detected.")
+    with w3:
+        st.markdown(f"**Market order impact** (${order_size:,.0f})")
+        buy = da.estimate_market_order(book.asks, order_size)
+        sell = da.estimate_market_order(book.bids, order_size)
+        impact = pd.DataFrame([
+            {"Side": "Market BUY", "VWAP": buy["vwap"], "Slippage (bps)": buy["slippage_bps"],
+             "Filled": f"{buy['fill_pct']:.1f}%"},
+            {"Side": "Market SELL", "VWAP": sell["vwap"], "Slippage (bps)": sell["slippage_bps"],
+             "Filled": f"{sell['fill_pct']:.1f}%"},
+        ])
+        st.dataframe(impact.style.format({"VWAP": "{:,.6g}", "Slippage (bps)": "{:.2f}"}),
+                     use_container_width=True, hide_index=True)
+
+    with st.expander("Raw order book data"):
+        st.json({
+            "symbol": book.symbol,
+            "lastUpdateId": book.last_update_id,
+            "bids": book.bids[:ladder_rows],
+            "asks": book.asks[:ladder_rows],
+        })
+
+
+if __name__ == "__main__":
+    main()

--- a/binance-dom/binance_client.py
+++ b/binance-dom/binance_client.py
@@ -1,0 +1,87 @@
+"""Thin client for Binance public market-data REST endpoints.
+
+No API key is required for any endpoint used here. The default base URL is
+Binance's market-data-only host (data-api.binance.vision), which serves the
+full Binance.com order book and is reachable from regions where
+api.binance.com returns HTTP 451.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+import requests
+
+BASE_URLS = {
+    "Binance.com market data (data-api.binance.vision)": "https://data-api.binance.vision",
+    "Binance.US (api.binance.us)": "https://api.binance.us",
+    "Binance.com (api.binance.com)": "https://api.binance.com",
+}
+
+DEFAULT_BASE_URL = BASE_URLS["Binance.com market data (data-api.binance.vision)"]
+
+DEPTH_LIMITS = [5, 10, 20, 50, 100, 500, 1000, 5000]
+
+
+class BinanceAPIError(RuntimeError):
+    """Raised when the Binance API returns a non-200 response."""
+
+
+@dataclass
+class OrderBook:
+    symbol: str
+    last_update_id: int
+    bids: list[tuple[float, float]]  # (price, qty) descending by price
+    asks: list[tuple[float, float]]  # (price, qty) ascending by price
+    fetched_at: float
+
+
+class BinanceClient:
+    def __init__(self, base_url: str = DEFAULT_BASE_URL, timeout: float = 10.0):
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self._session = requests.Session()
+        self._session.headers.update({"User-Agent": "binance-dom-interpreter/1.0"})
+
+    def _get(self, path: str, params: dict | None = None):
+        url = f"{self.base_url}{path}"
+        resp = self._session.get(url, params=params, timeout=self.timeout)
+        if resp.status_code != 200:
+            raise BinanceAPIError(f"GET {url} -> HTTP {resp.status_code}: {resp.text[:300]}")
+        return resp.json()
+
+    def ping(self) -> bool:
+        self._get("/api/v3/ping")
+        return True
+
+    def get_symbols(self, quote_assets: tuple[str, ...] = ("USDT",)) -> list[str]:
+        """All TRADING spot symbols for the given quote assets, sorted."""
+        info = self._get("/api/v3/exchangeInfo")
+        symbols = [
+            s["symbol"]
+            for s in info["symbols"]
+            if s["status"] == "TRADING" and s["quoteAsset"] in quote_assets
+        ]
+        return sorted(symbols)
+
+    def get_24h_tickers(self, quote_assets: tuple[str, ...] = ("USDT",)) -> list[dict]:
+        """24h ticker stats for every symbol, filtered by quote asset."""
+        data = self._get("/api/v3/ticker/24hr")
+        return [t for t in data if any(t["symbol"].endswith(q) for q in quote_assets)]
+
+    def get_price(self, symbol: str) -> float:
+        data = self._get("/api/v3/ticker/price", {"symbol": symbol})
+        return float(data["price"])
+
+    def get_order_book(self, symbol: str, limit: int = 100) -> OrderBook:
+        if limit not in DEPTH_LIMITS:
+            raise ValueError(f"limit must be one of {DEPTH_LIMITS}")
+        data = self._get("/api/v3/depth", {"symbol": symbol, "limit": limit})
+        return OrderBook(
+            symbol=symbol,
+            last_update_id=data["lastUpdateId"],
+            bids=[(float(p), float(q)) for p, q in data["bids"]],
+            asks=[(float(p), float(q)) for p, q in data["asks"]],
+            fetched_at=time.time(),
+        )

--- a/binance-dom/dom_analysis.py
+++ b/binance-dom/dom_analysis.py
@@ -1,0 +1,154 @@
+"""Interpretation logic for Binance depth-of-market (order book) data.
+
+All functions are pure and operate on plain sequences of (price, qty) tuples
+so they are easy to unit-test and reuse outside the Streamlit app.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from binance_client import OrderBook
+
+
+def to_frame(levels: list[tuple[float, float]]) -> pd.DataFrame:
+    df = pd.DataFrame(levels, columns=["price", "qty"])
+    df["quote"] = df["price"] * df["qty"]  # size denominated in quote currency
+    return df
+
+
+def best_prices(book: OrderBook) -> tuple[float, float]:
+    return book.bids[0][0], book.asks[0][0]
+
+
+def spread_metrics(book: OrderBook) -> dict:
+    bid, ask = best_prices(book)
+    mid = (bid + ask) / 2
+    spread = ask - bid
+    return {
+        "best_bid": bid,
+        "best_ask": ask,
+        "mid": mid,
+        "spread": spread,
+        "spread_bps": (spread / mid) * 1e4 if mid else 0.0,
+    }
+
+
+def depth_within_pct(book: OrderBook, pct: float) -> dict:
+    """Quote-denominated depth within +/-pct% of the mid price, plus imbalance.
+
+    Imbalance is (bid - ask) / (bid + ask): +1 means all bids, -1 all asks.
+    """
+    mid = spread_metrics(book)["mid"]
+    lo, hi = mid * (1 - pct / 100), mid * (1 + pct / 100)
+    bids = to_frame(book.bids)
+    asks = to_frame(book.asks)
+    bid_depth = bids.loc[bids["price"] >= lo, "quote"].sum()
+    ask_depth = asks.loc[asks["price"] <= hi, "quote"].sum()
+    total = bid_depth + ask_depth
+    return {
+        "band_pct": pct,
+        "bid_depth_quote": float(bid_depth),
+        "ask_depth_quote": float(ask_depth),
+        "imbalance": float((bid_depth - ask_depth) / total) if total else 0.0,
+    }
+
+
+def top_n_imbalance(book: OrderBook, n: int = 10) -> float:
+    """Imbalance across the top N levels on each side."""
+    bids = to_frame(book.bids).head(n)["quote"].sum()
+    asks = to_frame(book.asks).head(n)["quote"].sum()
+    total = bids + asks
+    return float((bids - asks) / total) if total else 0.0
+
+
+def cumulative_depth(book: OrderBook, max_pct: float = 5.0, points: int = 60) -> pd.DataFrame:
+    """Cumulative quote depth vs distance from mid, for both sides.
+
+    Returns a long-form frame: side ('Bids'/'Asks'), pct_from_mid, cum_quote.
+    """
+    mid = spread_metrics(book)["mid"]
+    rows = []
+    for side, levels in (("Bids", book.bids), ("Asks", book.asks)):
+        df = to_frame(levels)
+        df["pct_from_mid"] = (df["price"] - mid).abs() / mid * 100
+        df = df[df["pct_from_mid"] <= max_pct]
+        df["cum_quote"] = df["quote"].cumsum()
+        rows.append(df[["pct_from_mid", "cum_quote"]].assign(side=side))
+    return pd.concat(rows, ignore_index=True) if rows else pd.DataFrame()
+
+
+def detect_walls(
+    levels: list[tuple[float, float]], multiplier: float = 5.0, min_levels: int = 8
+) -> pd.DataFrame:
+    """Levels whose quote size exceeds multiplier x median level size."""
+    df = to_frame(levels)
+    if len(df) < min_levels:
+        return df.iloc[0:0].assign(size_vs_median=pd.Series(dtype=float))
+    median = df["quote"].median()
+    walls = df[df["quote"] >= multiplier * median].copy()
+    walls["size_vs_median"] = walls["quote"] / median
+    return walls.sort_values("quote", ascending=False).reset_index(drop=True)
+
+
+def estimate_market_order(
+    levels: list[tuple[float, float]], quote_amount: float
+) -> dict:
+    """Walk the book to price a market order of `quote_amount` quote currency.
+
+    Returns VWAP, slippage vs the best price, and how much of the order the
+    visible book can fill.
+    """
+    df = to_frame(levels)
+    best = df["price"].iloc[0]
+    remaining = quote_amount
+    cost_base = 0.0
+    for price, qty in zip(df["price"], df["qty"]):
+        level_quote = price * qty
+        take = min(level_quote, remaining)
+        cost_base += take / price
+        remaining -= take
+        if remaining <= 0:
+            break
+    filled = quote_amount - remaining
+    vwap = filled / cost_base if cost_base else 0.0
+    return {
+        "requested_quote": quote_amount,
+        "filled_quote": float(filled),
+        "fill_pct": float(filled / quote_amount * 100) if quote_amount else 0.0,
+        "vwap": float(vwap),
+        "slippage_bps": float(abs(vwap - best) / best * 1e4) if best else 0.0,
+        "fully_filled": bool(remaining <= 1e-9),
+    }
+
+
+def interpret(book: OrderBook, wall_multiplier: float = 5.0) -> list[str]:
+    """Plain-English read of the book, shown as bullet points in the UI."""
+    m = spread_metrics(book)
+    out = [
+        f"Spread is {m['spread']:.6g} ({m['spread_bps']:.2f} bps of mid) — "
+        + ("tight, liquid top of book." if m["spread_bps"] < 2 else
+           "moderate." if m["spread_bps"] < 10 else "wide; expect meaningful crossing cost.")
+    ]
+    for pct in (0.5, 2.0):
+        d = depth_within_pct(book, pct)
+        imb = d["imbalance"]
+        direction = "bid-heavy (buyers stacking)" if imb > 0.1 else \
+                    "ask-heavy (sellers stacking)" if imb < -0.1 else "balanced"
+        out.append(
+            f"Within ±{pct}% of mid: {direction} — imbalance {imb:+.2f}, "
+            f"bids ${d['bid_depth_quote']:,.0f} vs asks ${d['ask_depth_quote']:,.0f}."
+        )
+    bid_walls = detect_walls(book.bids, wall_multiplier)
+    ask_walls = detect_walls(book.asks, wall_multiplier)
+    if not bid_walls.empty:
+        w = bid_walls.iloc[0]
+        out.append(f"Largest bid wall: ${w['quote']:,.0f} at {w['price']:,.6g} "
+                   f"({w['size_vs_median']:.1f}× median level) — potential support.")
+    if not ask_walls.empty:
+        w = ask_walls.iloc[0]
+        out.append(f"Largest ask wall: ${w['quote']:,.0f} at {w['price']:,.6g} "
+                   f"({w['size_vs_median']:.1f}× median level) — potential resistance.")
+    if bid_walls.empty and ask_walls.empty:
+        out.append(f"No walls ≥ {wall_multiplier}× median level size detected.")
+    return out

--- a/binance-dom/requirements.txt
+++ b/binance-dom/requirements.txt
@@ -1,0 +1,5 @@
+streamlit>=1.36
+requests>=2.31
+pandas>=2.0
+plotly>=5.20
+streamlit-autorefresh>=1.0.1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

A new `binance-dom/` Streamlit app that pulls live **depth-of-market (order book)** data from the Binance public API for any spot ticker and interprets it.

## Features

- **Ticker choice** — searchable dropdown of every trading spot symbol, sorted by 24h quote volume, filterable by quote asset (USDT, FDUSD, USDC, BTC, ETH, ...)
- **Order book ladder** — bids/asks side by side with visual depth bars and cumulative size
- **Depth chart** — cumulative quote depth vs distance from mid price (Plotly)
- **Interpretation panel** — plain-English read of spread, ±0.5%/±2% depth imbalance, and largest walls (potential support/resistance)
- **Walls detection** — levels whose size exceeds a configurable multiple of the median level size
- **Market impact estimator** — walks the book to compute VWAP and slippage for a hypothetical market buy/sell
- **Auto-refresh** — optional live polling every 2–60 s
- **Endpoint selector** — defaults to `data-api.binance.vision` (Binance.com market data, no key needed, works where `api.binance.com` is geo-blocked with HTTP 451); Binance.US also available

## Layout

| File | Purpose |
| --- | --- |
| `binance-dom/binance_client.py` | REST client for Binance public market data (no API key) |
| `binance-dom/dom_analysis.py` | Pure interpretation functions: spread, imbalance, walls, slippage |
| `binance-dom/app.py` | Streamlit UI |

## Run it

```bash
cd binance-dom
python3 -m venv .venv && source .venv/bin/activate
pip install -r requirements.txt
streamlit run app.py
```

## Testing

- Smoke-tested the full pipeline against the live Binance API: symbol loading (487 USDT pairs), 24h volume ranking, 100-level book fetch for BTCUSDT, and all analysis functions (spread, imbalance bands, walls, slippage, interpretation).
- Verified the Streamlit app starts and serves HTTP 200 headless.
- Browser-verified the rendered UI: metric cards, interpretation bullets, depth chart, order book ladder, and walls tables all populate with live data, and switching the ticker BTCUSDT → ETHUSDT refreshes every component.

[Binance DOM Interpreter — BTCUSDT view](https://cursor.com/agents/bc-40228eb8-d74a-4347-b2bd-a0f14f674283/artifacts?path=%2Ftmp%2Fdom-app-screenshot.png)

No API key required — all endpoints are public market data.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40228eb8-d74a-4347-b2bd-a0f14f674283?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40228eb8-d74a-4347-b2bd-a0f14f674283&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

