### PR TITLE
Add Binance DOM order-book interpreter app

### DIFF
--- a/binance-dom/.gitignore
+++ b/binance-dom/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/binance-dom/README.md
+++ b/binance-dom/README.md
@@ -1,0 +1,75 @@
+# Binance DOM
+
+Live depth-of-market (order book) interpreter for any Binance spot ticker.
+A small FastAPI backend pulls the book from Binance, runs it through a set of
+pure-Python analytics, and streams the result to a single-page dashboard over a
+WebSocket. The same analytics work from the CLI or a notebook.
+
+## What it shows
+
+| Metric | Meaning |
+| --- | --- |
+| Mid / spread (bps) | Best bid/ask midpoint and how wide the book is |
+| Microprice + skew | Size-weighted mid; positive skew = price leaning up |
+| Imbalance (top-N) | `(bid - ask) / (bid + ask)` over the top N levels, in [-1, 1] |
+| Imbalance by distance | Same, but for everything resting within 5 / 10 / 25 / 50 / 100 bps of mid |
+| Market-order slippage | Avg fill vs mid (bps) for 1K / 10K / 100K / 1M quote-currency market orders |
+| Walls | Levels at least 4x the median size on their side |
+| Cumulative depth chart | Classic stepped bid/ask liquidity curve |
+| Imbalance history | Sparkline of top-N imbalance over the session |
+| Read | Coarse label (`balanced`, `mild buy pressure`, ...) from imbalance + microprice skew |
+
+## Run
+
+```bash
+cd binance-dom
+pip install -r requirements.txt
+python -m dom            # http://127.0.0.1:8000
+```
+
+Pick a quote asset, type or select a ticker, choose depth levels and hit
+Connect. 5/10/20 levels use Binance's `@depth20@100ms` stream (live);
+50+ levels poll the REST snapshot endpoint instead.
+
+### CLI
+
+```bash
+python -m dom BTCUSDT --limit 100          # table
+python -m dom ETHUSDT --limit 500 --json   # full analysis as JSON
+```
+
+### From Python
+
+```python
+from dom import OrderBook, analyze
+import httpx
+
+raw = httpx.get("https://data-api.binance.vision/api/v3/depth", params={"symbol": "BTCUSDT", "limit": 100}).json()
+book = OrderBook.from_binance("BTCUSDT", raw)
+a = analyze(book, top_n=5)
+print(a.signal, a.imbalance_top, a.slippage["100000"])
+```
+
+## API
+
+- `GET /api/symbols?quote=USDT&q=BTC` - tradable symbols (cached 10 min)
+- `GET /api/depth?symbol=BTCUSDT&limit=100` - raw Binance snapshot
+- `GET /api/analysis?symbol=BTCUSDT&limit=100&top_n=5` - snapshot + analytics
+- `GET /api/ticker?symbol=BTCUSDT` - 24h stats
+- `WS  /ws/{symbol}?levels=20&interval_ms=250&top_n=5` - streamed `{bids, asks, analysis}`
+
+## Endpoints and geo-blocking
+
+`api.binance.com` returns HTTP 451 in some regions. The client tries
+`data-api.binance.vision` (Binance's public market-data mirror) first, then
+falls back. Override the host list if needed:
+
+```bash
+BINANCE_REST_URLS=https://api.binance.us BINANCE_WS_URLS=wss://stream.binance.us:9443/ws python -m dom
+```
+
+## Tests
+
+```bash
+pytest
+```

--- a/binance-dom/dom/__init__.py
+++ b/binance-dom/dom/__init__.py
@@ -1,0 +1,5 @@
+"""Binance depth-of-market (DOM) interpreter."""
+
+from .analytics import DepthAnalysis, OrderBook, Wall, analyze
+
+__all__ = ["DepthAnalysis", "OrderBook", "Wall", "analyze"]

--- a/binance-dom/dom/__main__.py
+++ b/binance-dom/dom/__main__.py
@@ -1,0 +1,28 @@
+"""``python -m dom`` -> start the web app. ``python -m dom SYMBOL`` -> one-shot CLI analysis."""
+
+from __future__ import annotations
+
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) > 1 and not sys.argv[1].startswith("-"):
+        from .cli import main as cli_main
+
+        cli_main(sys.argv[1:])
+        return
+
+    import argparse
+
+    import uvicorn
+
+    p = argparse.ArgumentParser(description="Binance DOM web app")
+    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument("--port", type=int, default=8000)
+    p.add_argument("--reload", action="store_true")
+    args = p.parse_args()
+    uvicorn.run("dom.server:app", host=args.host, port=args.port, reload=args.reload, log_level="info")
+
+
+if __name__ == "__main__":
+    main()

--- a/binance-dom/dom/analytics.py
+++ b/binance-dom/dom/analytics.py
@@ -1,0 +1,316 @@
+"""Order-book (depth of market) analytics.
+
+Pure functions over a parsed :class:`OrderBook`. No I/O, so everything here is
+easy to reuse from a notebook or unit test.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from statistics import median
+from typing import Any, Iterable, Sequence
+
+Level = tuple[float, float]  # (price, quantity)
+
+
+@dataclass
+class OrderBook:
+    symbol: str
+    bids: list[Level]  # sorted descending by price
+    asks: list[Level]  # sorted ascending by price
+    last_update_id: int | None = None
+    timestamp_ms: int | None = None
+
+    @classmethod
+    def from_binance(cls, symbol: str, payload: dict[str, Any], timestamp_ms: int | None = None) -> "OrderBook":
+        """Build from a Binance ``/api/v3/depth`` or ``@depthN`` stream payload."""
+        bids = sorted(((float(p), float(q)) for p, q in payload.get("bids", [])), key=lambda l: -l[0])
+        asks = sorted(((float(p), float(q)) for p, q in payload.get("asks", [])), key=lambda l: l[0])
+        return cls(
+            symbol=symbol.upper(),
+            bids=[l for l in bids if l[1] > 0],
+            asks=[l for l in asks if l[1] > 0],
+            last_update_id=payload.get("lastUpdateId"),
+            timestamp_ms=timestamp_ms,
+        )
+
+    @property
+    def best_bid(self) -> Level | None:
+        return self.bids[0] if self.bids else None
+
+    @property
+    def best_ask(self) -> Level | None:
+        return self.asks[0] if self.asks else None
+
+    @property
+    def mid(self) -> float | None:
+        if not self.bids or not self.asks:
+            return None
+        return (self.bids[0][0] + self.asks[0][0]) / 2
+
+
+@dataclass
+class Wall:
+    side: str  # "bid" | "ask"
+    price: float
+    quantity: float
+    notional: float
+    ratio_to_median: float
+    distance_bps: float
+
+
+@dataclass
+class DepthAnalysis:
+    symbol: str
+    mid: float
+    spread: float
+    spread_bps: float
+    microprice: float
+    microprice_skew_bps: float
+    imbalance_top: float
+    imbalance_bands: dict[str, float]
+    bid_notional_bands: dict[str, float]
+    ask_notional_bands: dict[str, float]
+    bid_depth_qty: float
+    ask_depth_qty: float
+    bid_depth_notional: float
+    ask_depth_notional: float
+    slippage: dict[str, dict[str, float | None]]
+    walls: list[Wall]
+    levels: int
+    signal: str
+    cumulative_bids: list[dict[str, float]] = field(default_factory=list)
+    cumulative_asks: list[dict[str, float]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "symbol": self.symbol,
+            "mid": self.mid,
+            "spread": self.spread,
+            "spread_bps": self.spread_bps,
+            "microprice": self.microprice,
+            "microprice_skew_bps": self.microprice_skew_bps,
+            "imbalance_top": self.imbalance_top,
+            "imbalance_bands": self.imbalance_bands,
+            "bid_notional_bands": self.bid_notional_bands,
+            "ask_notional_bands": self.ask_notional_bands,
+            "bid_depth_qty": self.bid_depth_qty,
+            "ask_depth_qty": self.ask_depth_qty,
+            "bid_depth_notional": self.bid_depth_notional,
+            "ask_depth_notional": self.ask_depth_notional,
+            "slippage": self.slippage,
+            "walls": [w.__dict__ for w in self.walls],
+            "levels": self.levels,
+            "signal": self.signal,
+            "cumulative_bids": self.cumulative_bids,
+            "cumulative_asks": self.cumulative_asks,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Primitive metrics
+# ---------------------------------------------------------------------------
+
+
+def spread_bps(book: OrderBook) -> float:
+    mid = book.mid
+    if mid is None or mid == 0:
+        return 0.0
+    return (book.asks[0][0] - book.bids[0][0]) / mid * 1e4
+
+
+def microprice(book: OrderBook) -> float | None:
+    """Size-weighted mid. Leans towards the side with *less* resting size,
+    which is where price is statistically more likely to move."""
+    if not book.bids or not book.asks:
+        return None
+    bp, bq = book.bids[0]
+    ap, aq = book.asks[0]
+    if bq + aq == 0:
+        return (bp + ap) / 2
+    return (ap * bq + bp * aq) / (bq + aq)
+
+
+def imbalance(bid_qty: float, ask_qty: float) -> float:
+    """(bid - ask) / (bid + ask) in [-1, 1]. Positive = more bids (buy pressure)."""
+    total = bid_qty + ask_qty
+    return 0.0 if total == 0 else (bid_qty - ask_qty) / total
+
+
+def qty_within_bps(levels: Sequence[Level], mid: float, bps: float, side: str) -> tuple[float, float]:
+    """Return (quantity, notional) resting within ``bps`` of ``mid`` on one side."""
+    limit = mid * bps / 1e4
+    qty = notional = 0.0
+    for price, q in levels:
+        dist = mid - price if side == "bid" else price - mid
+        if dist > limit:
+            break
+        qty += q
+        notional += q * price
+    return qty, notional
+
+
+def cumulative(levels: Iterable[Level]) -> list[dict[str, float]]:
+    out: list[dict[str, float]] = []
+    cq = cn = 0.0
+    for price, q in levels:
+        cq += q
+        cn += q * price
+        out.append({"price": price, "qty": q, "cum_qty": cq, "cum_notional": cn})
+    return out
+
+
+def market_order_fill(levels: Sequence[Level], notional: float) -> dict[str, float | None]:
+    """Walk the book as a market order of ``notional`` (quote currency) would.
+
+    Returns avg fill price, worst price touched, base quantity filled and
+    whether the book had enough depth. ``avg_price`` is ``None`` if nothing fills.
+    """
+    remaining = notional
+    filled_qty = 0.0
+    spent = 0.0
+    worst = None
+    for price, q in levels:
+        if remaining <= 0:
+            break
+        take_notional = min(remaining, price * q)
+        take_qty = take_notional / price
+        filled_qty += take_qty
+        spent += take_notional
+        remaining -= take_notional
+        worst = price
+    avg = spent / filled_qty if filled_qty else None
+    return {
+        "avg_price": avg,
+        "worst_price": worst,
+        "filled_qty": filled_qty,
+        "filled_notional": spent,
+        "fully_filled": 1.0 if remaining <= 1e-9 else 0.0,
+    }
+
+
+def detect_walls(
+    levels: Sequence[Level],
+    mid: float,
+    side: str,
+    ratio: float = 4.0,
+    min_levels: int = 5,
+    min_share: float = 0.10,
+) -> list[Wall]:
+    """Flag levels whose size is ``ratio`` x the median size on that side *and*
+    holds at least ``min_share`` of the visible size on that side. The share
+    test stops dust-filled books (median ~0) from flagging everything."""
+    if len(levels) < min_levels:
+        return []
+    med = median(q for _, q in levels)
+    total = sum(q for _, q in levels)
+    if med <= 0 or total <= 0:
+        return []
+    walls: list[Wall] = []
+    for price, q in levels:
+        r = q / med
+        if r >= ratio and q / total >= min_share:
+            dist = (mid - price if side == "bid" else price - mid) / mid * 1e4
+            walls.append(Wall(side=side, price=price, quantity=q, notional=price * q, ratio_to_median=r, distance_bps=dist))
+    walls.sort(key=lambda w: -w.notional)
+    return walls
+
+
+def classify(imb_top: float, imb_bands: dict[str, float], skew_bps: float) -> str:
+    """Coarse, human-readable read of the book. Not trading advice."""
+    near = imb_bands.get("10", imb_top)
+    score = 0.5 * imb_top + 0.5 * near
+    if score > 0.35 and skew_bps > 0:
+        return "strong bid support / buy pressure"
+    if score > 0.15:
+        return "mild buy pressure"
+    if score < -0.35 and skew_bps < 0:
+        return "strong ask pressure / sell pressure"
+    if score < -0.15:
+        return "mild sell pressure"
+    return "balanced"
+
+
+# ---------------------------------------------------------------------------
+# Full analysis
+# ---------------------------------------------------------------------------
+
+DEFAULT_BANDS_BPS = (5.0, 10.0, 25.0, 50.0, 100.0)
+DEFAULT_ORDER_SIZES = (1_000.0, 10_000.0, 100_000.0, 1_000_000.0)
+
+
+def analyze(
+    book: OrderBook,
+    top_n: int = 5,
+    bands_bps: Sequence[float] = DEFAULT_BANDS_BPS,
+    order_sizes: Sequence[float] = DEFAULT_ORDER_SIZES,
+    wall_ratio: float = 4.0,
+    include_cumulative: bool = True,
+) -> DepthAnalysis:
+    if not book.bids or not book.asks:
+        raise ValueError("order book must have at least one bid and one ask")
+
+    mid = book.mid
+    assert mid is not None
+    spread = book.asks[0][0] - book.bids[0][0]
+    mp = microprice(book) or mid
+    skew_bps = (mp - mid) / mid * 1e4
+
+    top_bid = sum(q for _, q in book.bids[:top_n])
+    top_ask = sum(q for _, q in book.asks[:top_n])
+    imb_top = imbalance(top_bid, top_ask)
+
+    imb_bands: dict[str, float] = {}
+    bid_bands: dict[str, float] = {}
+    ask_bands: dict[str, float] = {}
+    for b in bands_bps:
+        bq, bn = qty_within_bps(book.bids, mid, b, "bid")
+        aq, an = qty_within_bps(book.asks, mid, b, "ask")
+        key = f"{b:g}"
+        imb_bands[key] = imbalance(bq, aq)
+        bid_bands[key] = bn
+        ask_bands[key] = an
+
+    bid_qty = sum(q for _, q in book.bids)
+    ask_qty = sum(q for _, q in book.asks)
+    bid_notional = sum(p * q for p, q in book.bids)
+    ask_notional = sum(p * q for p, q in book.asks)
+
+    slippage: dict[str, dict[str, float | None]] = {}
+    for size in order_sizes:
+        buy = market_order_fill(book.asks, size)
+        sell = market_order_fill(book.bids, size)
+        slippage[f"{size:g}"] = {
+            "buy_avg_price": buy["avg_price"],
+            "buy_slippage_bps": None if buy["avg_price"] is None else (buy["avg_price"] - mid) / mid * 1e4,
+            "buy_fully_filled": buy["fully_filled"],
+            "sell_avg_price": sell["avg_price"],
+            "sell_slippage_bps": None if sell["avg_price"] is None else (mid - sell["avg_price"]) / mid * 1e4,
+            "sell_fully_filled": sell["fully_filled"],
+        }
+
+    walls = detect_walls(book.bids, mid, "bid", wall_ratio) + detect_walls(book.asks, mid, "ask", wall_ratio)
+    walls.sort(key=lambda w: -w.notional)
+
+    return DepthAnalysis(
+        symbol=book.symbol,
+        mid=mid,
+        spread=spread,
+        spread_bps=spread / mid * 1e4,
+        microprice=mp,
+        microprice_skew_bps=skew_bps,
+        imbalance_top=imb_top,
+        imbalance_bands=imb_bands,
+        bid_notional_bands=bid_bands,
+        ask_notional_bands=ask_bands,
+        bid_depth_qty=bid_qty,
+        ask_depth_qty=ask_qty,
+        bid_depth_notional=bid_notional,
+        ask_depth_notional=ask_notional,
+        slippage=slippage,
+        walls=walls[:10],
+        levels=max(len(book.bids), len(book.asks)),
+        signal=classify(imb_top, imb_bands, skew_bps),
+        cumulative_bids=cumulative(book.bids) if include_cumulative else [],
+        cumulative_asks=cumulative(book.asks) if include_cumulative else [],
+    )

--- a/binance-dom/dom/cli.py
+++ b/binance-dom/dom/cli.py
@@ -1,0 +1,76 @@
+"""One-shot terminal view of an order book: ``python -m dom BTCUSDT --limit 50``."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+
+from .analytics import DepthAnalysis, OrderBook, analyze
+from .client import BinanceClient, BinanceError
+
+
+def _fmt(x: float | None, nd: int = 2) -> str:
+    return "-" if x is None else f"{x:,.{nd}f}"
+
+
+def render(a: DepthAnalysis, book: OrderBook, ladder: int) -> str:
+    lines = [
+        f"{a.symbol}  mid {_fmt(a.mid, 4)}  spread {_fmt(a.spread, 4)} ({a.spread_bps:.3f} bps)",
+        f"microprice {_fmt(a.microprice, 4)}  skew {a.microprice_skew_bps:+.2f} bps  ->  {a.signal.upper()}",
+        "",
+        f"imbalance top-N: {a.imbalance_top:+.3f}   " + "  ".join(f"{k}bps: {v:+.2f}" for k, v in a.imbalance_bands.items()),
+        f"depth ({a.levels} lvls)  bids {_fmt(a.bid_depth_notional, 0)}  asks {_fmt(a.ask_depth_notional, 0)} (quote ccy)",
+        "",
+        "market-order slippage (bps):",
+    ]
+    for size, s in a.slippage.items():
+        b = s["buy_slippage_bps"]
+        se = s["sell_slippage_bps"]
+        bflag = "" if s["buy_fully_filled"] else " (partial)"
+        sflag = "" if s["sell_fully_filled"] else " (partial)"
+        lines.append(f"  {float(size):>12,.0f}   buy {_fmt(b)}{bflag:<10} sell {_fmt(se)}{sflag}")
+    if a.walls:
+        lines += ["", "walls (>= ratio x median size):"]
+        for w in a.walls[:6]:
+            lines.append(f"  {w.side:<3} {w.price:>14,.4f}  qty {w.quantity:>12,.4f}  x{w.ratio_to_median:.1f}  {w.distance_bps:.1f} bps away")
+    lines += ["", f"{'BID QTY':>14} {'BID':>14} | {'ASK':<14} {'ASK QTY':<14}"]
+    for i in range(min(ladder, len(book.bids), len(book.asks))):
+        bp, bq = book.bids[i]
+        ap, aq = book.asks[i]
+        lines.append(f"{bq:>14,.4f} {bp:>14,.4f} | {ap:<14,.4f} {aq:<14,.4f}")
+    return "\n".join(lines)
+
+
+async def _run(symbol: str, limit: int, top_n: int, as_json: bool, ladder: int) -> int:
+    client = BinanceClient()
+    try:
+        raw = await client.depth(symbol, limit)
+    except BinanceError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+    finally:
+        await client.aclose()
+    book = OrderBook.from_binance(symbol, raw)
+    analysis = analyze(book, top_n=top_n, include_cumulative=as_json)
+    if as_json:
+        print(json.dumps(analysis.to_dict(), indent=2))
+    else:
+        print(render(analysis, book, ladder))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> None:
+    p = argparse.ArgumentParser(prog="python -m dom", description="Analyse a Binance order book")
+    p.add_argument("symbol", help="e.g. BTCUSDT")
+    p.add_argument("--limit", type=int, default=100, help="depth levels to fetch (5..5000)")
+    p.add_argument("--top-n", type=int, default=5, help="levels for top-of-book imbalance")
+    p.add_argument("--ladder", type=int, default=10, help="rows of the ladder to print")
+    p.add_argument("--json", action="store_true", help="emit JSON instead of a table")
+    args = p.parse_args(argv)
+    sys.exit(asyncio.run(_run(args.symbol, args.limit, args.top_n, args.json, args.ladder)))
+
+
+if __name__ == "__main__":
+    main()

--- a/binance-dom/dom/client.py
+++ b/binance-dom/dom/client.py
@@ -53,7 +53,11 @@ def snap_depth_limit(limit: int) -> int:
 
 
 class BinanceError(RuntimeError):
-    pass
+    """Upstream unreachable or returned an unexpected error."""
+
+
+class BadRequest(BinanceError):
+    """Binance rejected the request (e.g. unknown symbol); retrying won't help."""
 
 
 class BinanceClient:
@@ -79,7 +83,7 @@ class BinanceClient:
                     continue
                 if r.status_code == 400:
                     # Bad symbol etc. - no point retrying other hosts.
-                    raise BinanceError(r.json().get("msg", r.text))
+                    raise BadRequest(r.json().get("msg", r.text))
                 r.raise_for_status()
                 self._preferred = host
                 return r.json()

--- a/binance-dom/dom/client.py
+++ b/binance-dom/dom/client.py
@@ -1,0 +1,135 @@
+"""Thin Binance market-data client with endpoint fallback.
+
+Binance geo-blocks ``api.binance.com`` in some regions (HTTP 451). The public
+market-data mirror ``data-api.binance.vision`` serves the same read-only
+endpoints, so we try a list of hosts in order. Override with the
+``BINANCE_REST_URLS`` / ``BINANCE_WS_URLS`` environment variables
+(comma-separated) to pin a specific host, e.g. ``https://api.binance.us``.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+import httpx
+
+DEFAULT_REST_URLS = (
+    "https://data-api.binance.vision",
+    "https://api.binance.com",
+    "https://api1.binance.com",
+)
+DEFAULT_WS_URLS = (
+    "wss://data-stream.binance.vision/ws",
+    "wss://stream.binance.com:9443/ws",
+)
+
+VALID_DEPTH_LIMITS = (5, 10, 20, 50, 100, 500, 1000, 5000)
+STREAM_DEPTH_LEVELS = (5, 10, 20)
+
+
+def _env_list(name: str, default: tuple[str, ...]) -> tuple[str, ...]:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    return tuple(u.strip().rstrip("/") for u in raw.split(",") if u.strip())
+
+
+def rest_urls() -> tuple[str, ...]:
+    return _env_list("BINANCE_REST_URLS", DEFAULT_REST_URLS)
+
+
+def ws_urls() -> tuple[str, ...]:
+    return _env_list("BINANCE_WS_URLS", DEFAULT_WS_URLS)
+
+
+def snap_depth_limit(limit: int) -> int:
+    """Round up to the nearest limit Binance accepts."""
+    for l in VALID_DEPTH_LIMITS:
+        if limit <= l:
+            return l
+    return VALID_DEPTH_LIMITS[-1]
+
+
+class BinanceError(RuntimeError):
+    pass
+
+
+class BinanceClient:
+    def __init__(self, timeout: float = 10.0, client: httpx.AsyncClient | None = None):
+        self._client = client or httpx.AsyncClient(timeout=timeout, headers={"User-Agent": "binance-dom/0.1"})
+        self._preferred: str | None = None
+        self._symbols_cache: tuple[float, list[dict[str, Any]]] | None = None
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def _get(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        hosts = list(rest_urls())
+        if self._preferred in hosts:
+            hosts.remove(self._preferred)
+            hosts.insert(0, self._preferred)
+        last_err: Exception | None = None
+        for host in hosts:
+            try:
+                r = await self._client.get(f"{host}{path}", params=params)
+                if r.status_code == 451:
+                    last_err = BinanceError(f"{host} unavailable in this region (451)")
+                    continue
+                if r.status_code == 400:
+                    # Bad symbol etc. - no point retrying other hosts.
+                    raise BinanceError(r.json().get("msg", r.text))
+                r.raise_for_status()
+                self._preferred = host
+                return r.json()
+            except BinanceError:
+                raise
+            except Exception as e:  # network / 5xx
+                last_err = e
+        raise BinanceError(f"all Binance hosts failed: {last_err}")
+
+    async def depth(self, symbol: str, limit: int = 100) -> dict[str, Any]:
+        return await self._get("/api/v3/depth", {"symbol": symbol.upper(), "limit": snap_depth_limit(limit)})
+
+    async def symbols(self, quote: str | None = None, ttl: float = 600.0) -> list[dict[str, Any]]:
+        """Trading symbols from exchangeInfo, cached for ``ttl`` seconds."""
+        now = time.time()
+        if self._symbols_cache is None or now - self._symbols_cache[0] > ttl:
+            info = await self._get("/api/v3/exchangeInfo")
+            syms = [
+                {
+                    "symbol": s["symbol"],
+                    "base": s["baseAsset"],
+                    "quote": s["quoteAsset"],
+                    "tick_size": _tick_size(s),
+                }
+                for s in info.get("symbols", [])
+                if s.get("status") == "TRADING" and s.get("isSpotTradingAllowed", True)
+            ]
+            syms.sort(key=lambda s: s["symbol"])
+            self._symbols_cache = (now, syms)
+        out = self._symbols_cache[1]
+        if quote:
+            out = [s for s in out if s["quote"] == quote.upper()]
+        return out
+
+    async def ticker_24h(self, symbol: str) -> dict[str, Any]:
+        return await self._get("/api/v3/ticker/24hr", {"symbol": symbol.upper()})
+
+
+def _tick_size(sym: dict[str, Any]) -> float | None:
+    for f in sym.get("filters", []):
+        if f.get("filterType") == "PRICE_FILTER":
+            try:
+                return float(f["tickSize"])
+            except (KeyError, ValueError):
+                return None
+    return None
+
+
+def stream_url(symbol: str, levels: int = 20, speed_ms: int = 100, host: str | None = None) -> str:
+    levels = min(STREAM_DEPTH_LEVELS, key=lambda l: abs(l - levels))
+    speed = "100ms" if speed_ms <= 100 else "1000ms"
+    base = host or ws_urls()[0]
+    return f"{base}/{symbol.lower()}@depth{levels}@{speed}"

--- a/binance-dom/dom/server.py
+++ b/binance-dom/dom/server.py
@@ -15,11 +15,11 @@ from typing import Any
 
 import websockets
 from fastapi import FastAPI, HTTPException, Query, WebSocket, WebSocketDisconnect
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, Response
 from fastapi.staticfiles import StaticFiles
 
 from .analytics import OrderBook, analyze
-from .client import BinanceClient, BinanceError, stream_url, ws_urls
+from .client import BadRequest, BinanceClient, BinanceError, stream_url, ws_urls
 
 log = logging.getLogger("dom")
 STATIC_DIR = Path(__file__).resolve().parent.parent / "static"
@@ -65,6 +65,8 @@ def _analysis_payload(symbol: str, raw: dict[str, Any], top_n: int, wall_ratio: 
 async def api_symbols(quote: str | None = None, q: str | None = None, limit: int = Query(500, le=5000)):
     try:
         syms = await _client().symbols(quote=quote)
+    except BadRequest as e:
+        raise HTTPException(400, str(e))
     except BinanceError as e:
         raise HTTPException(502, str(e))
     if q:
@@ -77,6 +79,8 @@ async def api_symbols(quote: str | None = None, q: str | None = None, limit: int
 async def api_depth(symbol: str, limit: int = Query(100, ge=1, le=5000)):
     try:
         return await _client().depth(symbol, limit)
+    except BadRequest as e:
+        raise HTTPException(400, str(e))
     except BinanceError as e:
         raise HTTPException(502, str(e))
 
@@ -91,6 +95,8 @@ async def api_analysis(
     try:
         raw = await _client().depth(symbol, limit)
         return _analysis_payload(symbol, raw, top_n, wall_ratio, source="rest")
+    except BadRequest as e:
+        raise HTTPException(400, str(e))
     except BinanceError as e:
         raise HTTPException(502, str(e))
     except ValueError as e:
@@ -101,6 +107,8 @@ async def api_analysis(
 async def api_ticker(symbol: str):
     try:
         return await _client().ticker_24h(symbol)
+    except BadRequest as e:
+        raise HTTPException(400, str(e))
     except BinanceError as e:
         raise HTTPException(502, str(e))
 
@@ -218,6 +226,11 @@ async def ws_depth(
 @app.get("/", include_in_schema=False)
 async def index():
     return FileResponse(STATIC_DIR / "index.html")
+
+
+@app.get("/favicon.ico", include_in_schema=False)
+async def favicon():
+    return Response(status_code=204)
 
 
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")

--- a/binance-dom/dom/server.py
+++ b/binance-dom/dom/server.py
@@ -1,0 +1,223 @@
+"""FastAPI app: REST endpoints + a WebSocket that streams analysed depth.
+
+Run with ``uvicorn dom.server:app --reload`` or ``python -m dom``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import websockets
+from fastapi import FastAPI, HTTPException, Query, WebSocket, WebSocketDisconnect
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
+from .analytics import OrderBook, analyze
+from .client import BinanceClient, BinanceError, stream_url, ws_urls
+
+log = logging.getLogger("dom")
+STATIC_DIR = Path(__file__).resolve().parent.parent / "static"
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    app.state.client = BinanceClient()
+    try:
+        yield
+    finally:
+        await app.state.client.aclose()
+
+
+app = FastAPI(title="Binance DOM", version="0.1.0", lifespan=lifespan)
+
+
+def _client() -> BinanceClient:
+    return app.state.client
+
+
+def _analysis_payload(symbol: str, raw: dict[str, Any], top_n: int, wall_ratio: float, source: str) -> dict[str, Any]:
+    ts = int(time.time() * 1000)
+    book = OrderBook.from_binance(symbol, raw, timestamp_ms=ts)
+    analysis = analyze(book, top_n=top_n, wall_ratio=wall_ratio)
+    return {
+        "symbol": book.symbol,
+        "ts": ts,
+        "source": source,
+        "last_update_id": book.last_update_id,
+        "bids": book.bids,
+        "asks": book.asks,
+        "analysis": analysis.to_dict(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# REST
+# ---------------------------------------------------------------------------
+
+
+@app.get("/api/symbols")
+async def api_symbols(quote: str | None = None, q: str | None = None, limit: int = Query(500, le=5000)):
+    try:
+        syms = await _client().symbols(quote=quote)
+    except BinanceError as e:
+        raise HTTPException(502, str(e))
+    if q:
+        needle = q.upper()
+        syms = [s for s in syms if needle in s["symbol"]]
+    return {"count": len(syms), "symbols": syms[:limit]}
+
+
+@app.get("/api/depth")
+async def api_depth(symbol: str, limit: int = Query(100, ge=1, le=5000)):
+    try:
+        return await _client().depth(symbol, limit)
+    except BinanceError as e:
+        raise HTTPException(502, str(e))
+
+
+@app.get("/api/analysis")
+async def api_analysis(
+    symbol: str,
+    limit: int = Query(100, ge=5, le=5000),
+    top_n: int = Query(5, ge=1, le=100),
+    wall_ratio: float = Query(4.0, ge=1.0),
+):
+    try:
+        raw = await _client().depth(symbol, limit)
+        return _analysis_payload(symbol, raw, top_n, wall_ratio, source="rest")
+    except BinanceError as e:
+        raise HTTPException(502, str(e))
+    except ValueError as e:
+        raise HTTPException(422, str(e))
+
+
+@app.get("/api/ticker")
+async def api_ticker(symbol: str):
+    try:
+        return await _client().ticker_24h(symbol)
+    except BinanceError as e:
+        raise HTTPException(502, str(e))
+
+
+# ---------------------------------------------------------------------------
+# WebSocket: live analysed depth
+# ---------------------------------------------------------------------------
+
+
+async def _binance_stream(symbol: str, levels: int, queue: asyncio.Queue[dict[str, Any]], stop: asyncio.Event) -> None:
+    """Pump raw depth payloads from Binance into ``queue``. Tries each WS host;
+    raises if none can be reached so the caller can fall back to polling."""
+    last_err: Exception | None = None
+    for host in ws_urls():
+        url = stream_url(symbol, levels=levels, host=host)
+        try:
+            async with websockets.connect(url, open_timeout=8, ping_interval=20) as ws:
+                log.info("connected to %s", url)
+                while not stop.is_set():
+                    msg = await asyncio.wait_for(ws.recv(), timeout=30)
+                    payload = json.loads(msg)
+                    if "bids" in payload:
+                        # Drop stale frames if the consumer is slower than 100ms.
+                        while not queue.empty():
+                            queue.get_nowait()
+                        queue.put_nowait(payload)
+                return
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # connection refused / 451 / timeout
+            last_err = e
+            log.warning("stream %s failed: %s", url, e)
+    raise ConnectionError(f"no Binance WS host reachable: {last_err}")
+
+
+async def _rest_poller(symbol: str, levels: int, queue: asyncio.Queue[dict[str, Any]], stop: asyncio.Event, interval: float) -> None:
+    while not stop.is_set():
+        try:
+            payload = await _client().depth(symbol, levels)
+            while not queue.empty():
+                queue.get_nowait()
+            queue.put_nowait(payload)
+        except BinanceError as e:
+            queue.put_nowait({"error": str(e)})
+        await asyncio.sleep(interval)
+
+
+@app.websocket("/ws/{symbol}")
+async def ws_depth(
+    websocket: WebSocket,
+    symbol: str,
+    levels: int = Query(20, ge=5, le=1000),
+    interval_ms: int = Query(250, ge=100, le=5000),
+    top_n: int = Query(5, ge=1, le=100),
+    wall_ratio: float = Query(4.0, ge=1.0),
+):
+    await websocket.accept()
+    queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+    stop = asyncio.Event()
+    source = "binance-ws" if levels <= 20 else "rest-poll"
+
+    async def producer() -> None:
+        nonlocal source
+        if source == "binance-ws":
+            try:
+                await _binance_stream(symbol, levels, queue, stop)
+                return
+            except ConnectionError as e:
+                log.warning("falling back to REST polling for %s: %s", symbol, e)
+                source = "rest-poll"
+                await websocket.send_json({"type": "info", "message": "live stream unavailable, polling REST"})
+        await _rest_poller(symbol, levels, queue, stop, interval=max(interval_ms, 500) / 1000)
+
+    producer_task = asyncio.create_task(producer())
+    last_sent = 0.0
+    try:
+        while True:
+            payload = await queue.get()
+            if "error" in payload:
+                await websocket.send_json({"type": "error", "message": payload["error"]})
+                continue
+            now = time.monotonic()
+            if now - last_sent < interval_ms / 1000:
+                continue
+            last_sent = now
+            try:
+                out = _analysis_payload(symbol, payload, top_n, wall_ratio, source)
+            except ValueError as e:
+                await websocket.send_json({"type": "error", "message": str(e)})
+                continue
+            out["type"] = "depth"
+            await websocket.send_json(out)
+    except WebSocketDisconnect:
+        pass
+    except Exception as e:  # noqa: BLE001
+        log.exception("ws error for %s", symbol)
+        try:
+            await websocket.send_json({"type": "error", "message": str(e)})
+        except Exception:  # noqa: BLE001
+            pass
+    finally:
+        stop.set()
+        producer_task.cancel()
+        try:
+            await producer_task
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Static frontend
+# ---------------------------------------------------------------------------
+
+
+@app.get("/", include_in_schema=False)
+async def index():
+    return FileResponse(STATIC_DIR / "index.html")
+
+
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")

--- a/binance-dom/requirements.txt
+++ b/binance-dom/requirements.txt
@@ -1,0 +1,5 @@
+fastapi>=0.110
+uvicorn[standard]>=0.29
+httpx>=0.27
+websockets>=12
+pytest>=8

--- a/binance-dom/static/app.js
+++ b/binance-dom/static/app.js
@@ -105,7 +105,7 @@
 
     $("m-mid").textContent = fmt(a.mid, priceDecimals);
     $("m-spread").textContent = fmt(a.spread, priceDecimals);
-    $("m-spread-bps").textContent = `${a.spread_bps.toFixed(2)} bps`;
+    $("m-spread-bps").textContent = `${a.spread_bps.toFixed(3)} bps`;
     $("m-micro").textContent = fmt(a.microprice, priceDecimals);
     $("m-skew").textContent = `${signed(a.microprice_skew_bps)} bps vs mid`;
     $("m-imb").textContent = signed(a.imbalance_top, 3);
@@ -139,7 +139,7 @@
     };
     els.asks.innerHTML = msg.asks.slice(0, n).map((l, i) => row(l, a.cumulative_asks[i])).reverse().join("");
     els.bids.innerHTML = msg.bids.slice(0, n).map((l, i) => row(l, a.cumulative_bids[i])).join("");
-    els.midRow.innerHTML = `mid <b>${fmt(a.mid, priceDecimals)}</b> · spread ${a.spread_bps.toFixed(2)} bps`;
+    els.midRow.innerHTML = `mid <b>${fmt(a.mid, priceDecimals)}</b> · spread ${a.spread_bps.toFixed(3)} bps`;
   }
 
   function renderBands(a) {

--- a/binance-dom/static/app.js
+++ b/binance-dom/static/app.js
@@ -1,0 +1,249 @@
+(() => {
+  const $ = (id) => document.getElementById(id);
+  const els = {
+    form: $("controls"), quote: $("quote"), symbol: $("symbol"), levels: $("levels"), topn: $("topn"),
+    symbols: $("symbols"), status: $("status"), asks: $("asks"), bids: $("bids"), midRow: $("mid-row"),
+    depth: $("depth"), history: $("history"), bands: $("bands").querySelector("tbody"),
+    slip: $("slip").querySelector("tbody"), walls: $("walls"), signalCard: document.querySelector(".card.signal"),
+  };
+
+  let ws = null;
+  let priceDecimals = 2;
+  let qtyDecimals = 4;
+  const history = []; // {t, imb}
+  const HISTORY_MAX = 1200;
+
+  // ---------- formatting ----------
+  const fmt = (x, d = 2) => (x == null || Number.isNaN(x)) ? "-" : Number(x).toLocaleString("en-US", { minimumFractionDigits: d, maximumFractionDigits: d });
+  const fmtBig = (x) => {
+    if (x == null) return "-";
+    const a = Math.abs(x);
+    if (a >= 1e9) return (x / 1e9).toFixed(2) + "B";
+    if (a >= 1e6) return (x / 1e6).toFixed(2) + "M";
+    if (a >= 1e3) return (x / 1e3).toFixed(1) + "K";
+    return x.toFixed(0);
+  };
+  const signed = (x, d = 2) => (x == null ? "-" : (x >= 0 ? "+" : "") + Number(x).toFixed(d));
+  const decimalsFor = (tick) => {
+    if (!tick) return 2;
+    const s = tick.toString();
+    if (s.includes("e-")) return parseInt(s.split("e-")[1], 10);
+    return Math.max(0, (s.split(".")[1] || "").replace(/0+$/, "").length);
+  };
+  const inferDecimals = (levels) => {
+    let d = 0;
+    for (const [p, q] of levels) {
+      const ps = String(p).split(".")[1] || ""; const qs = String(q).split(".")[1] || "";
+      d = Math.max(d, ps.length);
+      qtyDecimals = Math.max(Math.min(qs.length, 6), 2);
+    }
+    return Math.min(d, 8);
+  };
+
+  // ---------- symbols ----------
+  let symbolMeta = new Map();
+  async function loadSymbols() {
+    const quote = els.quote.value;
+    const url = quote ? `/api/symbols?quote=${quote}&limit=5000` : "/api/symbols?limit=5000";
+    try {
+      const r = await fetch(url);
+      const data = await r.json();
+      symbolMeta = new Map(data.symbols.map((s) => [s.symbol, s]));
+      els.symbols.innerHTML = data.symbols.map((s) => `<option value="${s.symbol}">${s.base}/${s.quote}</option>`).join("");
+    } catch (e) {
+      setStatus("warn", "symbol list unavailable");
+    }
+  }
+
+  // ---------- status ----------
+  function setStatus(cls, text) {
+    els.status.className = `status ${cls}`;
+    els.status.textContent = text;
+  }
+
+  // ---------- websocket ----------
+  function connect() {
+    if (ws) { ws.onclose = null; ws.close(); ws = null; }
+    const symbol = els.symbol.value.trim().toUpperCase();
+    if (!symbol) return;
+    els.symbol.value = symbol;
+    history.length = 0;
+    const meta = symbolMeta.get(symbol);
+    priceDecimals = meta ? decimalsFor(meta.tick_size) : 2;
+    const params = new URLSearchParams({ levels: els.levels.value, top_n: els.topn.value, interval_ms: "250" });
+    const proto = location.protocol === "https:" ? "wss" : "ws";
+    ws = new WebSocket(`${proto}://${location.host}/ws/${symbol}?${params}`);
+    setStatus("warn", `connecting ${symbol}…`);
+    document.title = `${symbol} · Binance DOM`;
+    ws.onopen = () => setStatus("warn", `waiting for data…`);
+    ws.onmessage = (ev) => {
+      const msg = JSON.parse(ev.data);
+      if (msg.type === "depth") { setStatus("on", `${symbol} · ${msg.source}`); render(msg); }
+      else if (msg.type === "error") setStatus("off", msg.message);
+      else if (msg.type === "info") setStatus("warn", msg.message);
+    };
+    ws.onclose = () => setStatus("off", "disconnected");
+    ws.onerror = () => setStatus("off", "connection error");
+    loadTicker(symbol);
+  }
+
+  async function loadTicker(symbol) {
+    try {
+      const r = await fetch(`/api/ticker?symbol=${symbol}`);
+      if (!r.ok) return;
+      const t = await r.json();
+      const chg = parseFloat(t.priceChangePercent);
+      $("m-ticker").innerHTML = `24h <span class="${chg >= 0 ? "bid" : "ask"}">${signed(chg)}%</span> · vol ${fmtBig(parseFloat(t.quoteVolume))}`;
+    } catch (_) { /* ignore */ }
+  }
+
+  // ---------- render ----------
+  function render(msg) {
+    const a = msg.analysis;
+    if (!symbolMeta.has(msg.symbol)) priceDecimals = inferDecimals(msg.bids.concat(msg.asks));
+    else inferDecimals(msg.bids.concat(msg.asks));
+
+    $("m-mid").textContent = fmt(a.mid, priceDecimals);
+    $("m-spread").textContent = fmt(a.spread, priceDecimals);
+    $("m-spread-bps").textContent = `${a.spread_bps.toFixed(2)} bps`;
+    $("m-micro").textContent = fmt(a.microprice, priceDecimals);
+    $("m-skew").textContent = `${signed(a.microprice_skew_bps)} bps vs mid`;
+    $("m-imb").textContent = signed(a.imbalance_top, 3);
+    $("m-imb").className = "v " + (a.imbalance_top > 0.05 ? "bid" : a.imbalance_top < -0.05 ? "ask" : "");
+    $("m-imb-fill").style.width = `${((a.imbalance_top + 1) / 2) * 100}%`;
+    $("m-bidn").textContent = fmtBig(a.bid_depth_notional);
+    $("m-askn").textContent = fmtBig(a.ask_depth_notional);
+    $("m-levels").textContent = `${a.levels} levels/side · ${a.bid_depth_qty.toFixed(qtyDecimals)} / ${a.ask_depth_qty.toFixed(qtyDecimals)} base`;
+    $("m-signal").textContent = a.signal;
+    $("m-source").textContent = `${msg.source} · ${new Date(msg.ts).toLocaleTimeString()}`;
+    els.signalCard.className = "card signal " + (a.signal.includes("buy") ? "buy" : a.signal.includes("sell") ? "sell" : "");
+
+    renderLadder(msg, a);
+    renderBands(a);
+    renderSlippage(a);
+    renderWalls(a);
+    drawDepth(a);
+    history.push({ t: msg.ts, imb: a.imbalance_top });
+    if (history.length > HISTORY_MAX) history.shift();
+    drawHistory();
+  }
+
+  function renderLadder(msg, a) {
+    const n = Math.min(20, msg.bids.length, msg.asks.length);
+    const wallPrices = new Set(a.walls.map((w) => w.price));
+    const maxCum = Math.max(a.cumulative_bids[n - 1]?.cum_notional || 0, a.cumulative_asks[n - 1]?.cum_notional || 0) || 1;
+    const row = (lvl, cum) => {
+      const pct = Math.min(100, (cum.cum_notional / maxCum) * 100);
+      const cls = wallPrices.has(lvl[0]) ? "row wall" : "row";
+      return `<div class="${cls}"><div class="bar" style="width:${pct}%"></div><span>${fmt(lvl[0], priceDecimals)}</span><span>${fmt(lvl[1], qtyDecimals)}</span><span>${fmtBig(cum.cum_notional)}</span></div>`;
+    };
+    els.asks.innerHTML = msg.asks.slice(0, n).map((l, i) => row(l, a.cumulative_asks[i])).reverse().join("");
+    els.bids.innerHTML = msg.bids.slice(0, n).map((l, i) => row(l, a.cumulative_bids[i])).join("");
+    els.midRow.innerHTML = `mid <b>${fmt(a.mid, priceDecimals)}</b> · spread ${a.spread_bps.toFixed(2)} bps`;
+  }
+
+  function renderBands(a) {
+    els.bands.innerHTML = Object.keys(a.imbalance_bands).map((k) => {
+      const imb = a.imbalance_bands[k];
+      const cls = imb > 0.05 ? "bid" : imb < -0.05 ? "ask" : "";
+      return `<tr><td>${k} bps</td><td class="bid">${fmtBig(a.bid_notional_bands[k])}</td><td class="ask">${fmtBig(a.ask_notional_bands[k])}</td><td class="${cls}">${signed(imb)}</td></tr>`;
+    }).join("");
+  }
+
+  function renderSlippage(a) {
+    els.slip.innerHTML = Object.entries(a.slippage).map(([size, s]) => {
+      const cell = (bps, full) => bps == null ? '<span class="muted">n/a</span>' : `${bps.toFixed(2)} bps${full ? "" : ' <span class="muted">(partial)</span>'}`;
+      return `<tr><td>${fmtBig(parseFloat(size))}</td><td>${cell(s.buy_slippage_bps, s.buy_fully_filled)}</td><td>${cell(s.sell_slippage_bps, s.sell_fully_filled)}</td></tr>`;
+    }).join("");
+  }
+
+  function renderWalls(a) {
+    if (!a.walls.length) { els.walls.innerHTML = '<li class="muted">none detected in visible depth</li>'; return; }
+    els.walls.innerHTML = a.walls.slice(0, 8).map((w) =>
+      `<li><span class="${w.side}">${w.side.toUpperCase()}</span> ${fmt(w.price, priceDecimals)} · ${fmt(w.quantity, qtyDecimals)} (${fmtBig(w.notional)}) · ${w.ratio_to_median.toFixed(1)}x median · ${w.distance_bps.toFixed(1)} bps away</li>`
+    ).join("");
+  }
+
+  // ---------- charts ----------
+  function drawDepth(a) {
+    const c = els.depth, ctx = c.getContext("2d");
+    const W = c.width, H = c.height, pad = { l: 60, r: 16, t: 12, b: 28 };
+    ctx.clearRect(0, 0, W, H);
+    const bids = a.cumulative_bids, asks = a.cumulative_asks;
+    if (!bids.length || !asks.length) return;
+    const pMin = bids[bids.length - 1].price, pMax = asks[asks.length - 1].price;
+    const yMax = Math.max(bids[bids.length - 1].cum_notional, asks[asks.length - 1].cum_notional) * 1.05;
+    const x = (p) => pad.l + ((p - pMin) / (pMax - pMin || 1)) * (W - pad.l - pad.r);
+    const y = (v) => H - pad.b - (v / yMax) * (H - pad.t - pad.b);
+
+    // grid + axes
+    ctx.strokeStyle = "#232b3b"; ctx.fillStyle = "#7d8aa3"; ctx.font = "11px ui-monospace, monospace"; ctx.lineWidth = 1;
+    for (let i = 0; i <= 4; i++) {
+      const v = (yMax / 4) * i, yy = y(v);
+      ctx.beginPath(); ctx.moveTo(pad.l, yy); ctx.lineTo(W - pad.r, yy); ctx.stroke();
+      ctx.textAlign = "right"; ctx.fillText(fmtBig(v), pad.l - 6, yy + 4);
+    }
+    ctx.textAlign = "center";
+    for (let i = 0; i <= 4; i++) {
+      const p = pMin + ((pMax - pMin) / 4) * i;
+      ctx.fillText(fmt(p, priceDecimals), x(p), H - 8);
+    }
+
+    const step = (levels, color, dir) => {
+      ctx.beginPath();
+      ctx.moveTo(x(dir > 0 ? a.mid : a.mid), y(0));
+      let prevY = y(0);
+      for (const l of levels) {
+        ctx.lineTo(x(l.price), prevY);
+        ctx.lineTo(x(l.price), y(l.cum_notional));
+        prevY = y(l.cum_notional);
+      }
+      const last = levels[levels.length - 1];
+      ctx.lineTo(x(last.price), y(0));
+      ctx.closePath();
+      ctx.fillStyle = color + "33"; ctx.fill();
+      ctx.strokeStyle = color; ctx.lineWidth = 1.5; ctx.stroke();
+    };
+    step(bids, "#22c55e", -1);
+    step(asks, "#ef4444", 1);
+
+    // mid line
+    ctx.strokeStyle = "#f0b90b"; ctx.setLineDash([4, 4]);
+    ctx.beginPath(); ctx.moveTo(x(a.mid), pad.t); ctx.lineTo(x(a.mid), H - pad.b); ctx.stroke();
+    ctx.setLineDash([]);
+  }
+
+  function drawHistory() {
+    const c = els.history, ctx = c.getContext("2d");
+    const W = c.width, H = c.height, pad = 8;
+    ctx.clearRect(0, 0, W, H);
+    const mid = H / 2;
+    ctx.strokeStyle = "#232b3b"; ctx.beginPath(); ctx.moveTo(0, mid); ctx.lineTo(W, mid); ctx.stroke();
+    if (history.length < 2) return;
+    const x = (i) => (i / (HISTORY_MAX - 1)) * (W - pad * 2) + pad;
+    const y = (v) => mid - v * (H / 2 - pad);
+    const offset = HISTORY_MAX - history.length;
+    // fill positive green / negative red
+    for (let i = 1; i < history.length; i++) {
+      const v = history[i].imb;
+      ctx.fillStyle = v >= 0 ? "#22c55e55" : "#ef444455";
+      const x0 = x(offset + i - 1), x1 = x(offset + i);
+      ctx.fillRect(x0, Math.min(mid, y(v)), Math.max(1, x1 - x0), Math.abs(y(v) - mid));
+    }
+    ctx.strokeStyle = "#dfe6f2"; ctx.lineWidth = 1; ctx.beginPath();
+    history.forEach((h, i) => { const px = x(offset + i), py = y(h.imb); i ? ctx.lineTo(px, py) : ctx.moveTo(px, py); });
+    ctx.stroke();
+    ctx.fillStyle = "#7d8aa3"; ctx.font = "11px ui-monospace, monospace"; ctx.textAlign = "left";
+    ctx.fillText("+1 bids", 4, 12); ctx.fillText("-1 asks", 4, H - 4);
+  }
+
+  // ---------- wire up ----------
+  els.form.addEventListener("submit", (e) => { e.preventDefault(); connect(); });
+  els.quote.addEventListener("change", loadSymbols);
+  els.levels.addEventListener("change", () => ws && connect());
+  els.topn.addEventListener("change", () => ws && connect());
+
+  const initial = new URLSearchParams(location.search).get("symbol");
+  if (initial) els.symbol.value = initial.toUpperCase();
+  loadSymbols().then(connect);
+})();

--- a/binance-dom/static/index.html
+++ b/binance-dom/static/index.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Binance DOM</title>
+  <link rel="stylesheet" href="/static/style.css" />
+</head>
+<body>
+  <header>
+    <div class="brand">Binance <span>DOM</span></div>
+    <form id="controls" autocomplete="off">
+      <label>Quote
+        <select id="quote">
+          <option>USDT</option><option>FDUSD</option><option>USDC</option><option>BTC</option><option>ETH</option><option>BNB</option><option value="">all</option>
+        </select>
+      </label>
+      <label>Ticker
+        <input id="symbol" list="symbols" placeholder="BTCUSDT" value="BTCUSDT" spellcheck="false" />
+        <datalist id="symbols"></datalist>
+      </label>
+      <label>Levels
+        <select id="levels">
+          <option value="5">5 (live)</option><option value="10">10 (live)</option><option value="20" selected>20 (live)</option>
+          <option value="50">50 (poll)</option><option value="100">100 (poll)</option><option value="500">500 (poll)</option>
+        </select>
+      </label>
+      <label>Top-N
+        <input id="topn" type="number" min="1" max="100" value="5" />
+      </label>
+      <button type="submit">Connect</button>
+    </form>
+    <div id="status" class="status off">disconnected</div>
+  </header>
+
+  <section class="metrics">
+    <div class="card"><div class="k">Mid</div><div class="v" id="m-mid">-</div><div class="s" id="m-ticker">-</div></div>
+    <div class="card"><div class="k">Spread</div><div class="v" id="m-spread">-</div><div class="s" id="m-spread-bps">-</div></div>
+    <div class="card"><div class="k">Microprice</div><div class="v" id="m-micro">-</div><div class="s" id="m-skew">-</div></div>
+    <div class="card"><div class="k">Imbalance (top-N)</div><div class="v" id="m-imb">-</div><div class="s"><div class="imbbar"><div id="m-imb-fill"></div></div></div></div>
+    <div class="card"><div class="k">Book depth (quote)</div><div class="v small"><span class="bid" id="m-bidn">-</span> / <span class="ask" id="m-askn">-</span></div><div class="s" id="m-levels">-</div></div>
+    <div class="card signal"><div class="k">Read</div><div class="v small" id="m-signal">-</div><div class="s" id="m-source">-</div></div>
+  </section>
+
+  <main>
+    <section class="panel ladder">
+      <h2>Ladder</h2>
+      <div class="ladder-head"><span>Price</span><span>Size</span><span>Cum (quote)</span></div>
+      <div id="asks" class="rows asks"></div>
+      <div id="mid-row" class="mid-row">-</div>
+      <div id="bids" class="rows bids"></div>
+    </section>
+
+    <section class="panel chart">
+      <h2>Cumulative depth</h2>
+      <canvas id="depth" width="800" height="360"></canvas>
+      <h2>Imbalance history <small>(top-N, last ~5 min)</small></h2>
+      <canvas id="history" width="800" height="120"></canvas>
+    </section>
+
+    <section class="panel side">
+      <h2>Imbalance by distance</h2>
+      <table id="bands"><thead><tr><th>Within</th><th>Bids</th><th>Asks</th><th>Imb</th></tr></thead><tbody></tbody></table>
+      <h2>Market-order slippage</h2>
+      <table id="slip"><thead><tr><th>Size</th><th>Buy</th><th>Sell</th></tr></thead><tbody></tbody></table>
+      <h2>Walls <small>(&ge;4x median size)</small></h2>
+      <ul id="walls"><li class="muted">none</li></ul>
+    </section>
+  </main>
+
+  <footer>Public market data via Binance. Not financial advice.</footer>
+  <script src="/static/app.js"></script>
+</body>
+</html>

--- a/binance-dom/static/style.css
+++ b/binance-dom/static/style.css
@@ -1,0 +1,78 @@
+:root {
+  --bg: #0b0e14;
+  --panel: #131824;
+  --panel-2: #1a2130;
+  --border: #232b3b;
+  --text: #dfe6f2;
+  --muted: #7d8aa3;
+  --bid: #22c55e;
+  --ask: #ef4444;
+  --accent: #f0b90b;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+* { box-sizing: border-box; }
+body { margin: 0; background: var(--bg); color: var(--text); font-size: 14px; }
+header {
+  display: flex; align-items: center; gap: 20px; flex-wrap: wrap;
+  padding: 12px 20px; border-bottom: 1px solid var(--border); background: var(--panel);
+}
+.brand { font-weight: 700; font-size: 18px; letter-spacing: .5px; }
+.brand span { color: var(--accent); }
+#controls { display: flex; gap: 12px; align-items: flex-end; flex-wrap: wrap; }
+#controls label { display: flex; flex-direction: column; font-size: 11px; color: var(--muted); gap: 4px; text-transform: uppercase; }
+#controls input, #controls select, #controls button {
+  background: var(--panel-2); color: var(--text); border: 1px solid var(--border); border-radius: 6px;
+  padding: 7px 10px; font-size: 14px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+#controls input#symbol { width: 150px; text-transform: uppercase; }
+#controls input#topn { width: 70px; }
+#controls button { background: var(--accent); color: #111; font-weight: 600; cursor: pointer; border: none; }
+.status { margin-left: auto; padding: 5px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; }
+.status.off { background: #3a1d1d; color: #fca5a5; }
+.status.on { background: #14351f; color: #86efac; }
+.status.warn { background: #3b2f10; color: #fcd34d; }
+
+.metrics { display: grid; grid-template-columns: repeat(6, 1fr); gap: 12px; padding: 16px 20px 0; }
+.card { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 12px 14px; min-height: 84px; }
+.card .k { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .5px; }
+.card .v { font-size: 22px; font-weight: 600; margin-top: 4px; font-family: ui-monospace, Menlo, monospace; }
+.card .v.small { font-size: 15px; }
+.card .s { font-size: 12px; color: var(--muted); margin-top: 4px; font-family: ui-monospace, Menlo, monospace; }
+.card.signal .v { text-transform: capitalize; }
+.card.signal.buy .v { color: var(--bid); }
+.card.signal.sell .v { color: var(--ask); }
+.imbbar { position: relative; height: 8px; background: var(--ask); border-radius: 4px; overflow: hidden; margin-top: 6px; }
+.imbbar div { height: 100%; background: var(--bid); width: 50%; transition: width .2s; }
+
+main { display: grid; grid-template-columns: 320px 1fr 340px; gap: 12px; padding: 16px 20px; }
+.panel { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 12px 14px; overflow: hidden; }
+.panel h2 { font-size: 12px; text-transform: uppercase; color: var(--muted); margin: 4px 0 10px; letter-spacing: .5px; }
+.panel h2 small { text-transform: none; font-weight: 400; letter-spacing: 0; }
+canvas { width: 100%; height: auto; display: block; border-radius: 6px; background: var(--panel-2); margin-bottom: 14px; }
+
+.ladder-head, .row { display: grid; grid-template-columns: 1.3fr 1fr 1fr; font-family: ui-monospace, Menlo, monospace; font-size: 12.5px; }
+.ladder-head { color: var(--muted); font-size: 11px; padding: 0 6px 6px; text-transform: uppercase; }
+.ladder-head span:not(:first-child), .row span:not(:first-child) { text-align: right; }
+.row { position: relative; padding: 2px 6px; line-height: 18px; }
+.row .bar { position: absolute; top: 0; bottom: 0; right: 0; opacity: .18; z-index: 0; }
+.row span { position: relative; z-index: 1; }
+.rows.asks .row span:first-child { color: var(--ask); }
+.rows.asks .row .bar { background: var(--ask); }
+.rows.bids .row span:first-child { color: var(--bid); }
+.rows.bids .row .bar { background: var(--bid); }
+.row.wall span:first-child { font-weight: 700; text-decoration: underline dotted; }
+.mid-row { text-align: center; padding: 6px; margin: 4px 0; background: var(--panel-2); border-radius: 6px; font-family: ui-monospace, Menlo, monospace; font-size: 13px; }
+
+table { width: 100%; border-collapse: collapse; font-family: ui-monospace, Menlo, monospace; font-size: 12.5px; margin-bottom: 14px; }
+th { text-align: right; color: var(--muted); font-weight: 500; font-size: 11px; text-transform: uppercase; padding: 4px 6px; border-bottom: 1px solid var(--border); }
+th:first-child, td:first-child { text-align: left; }
+td { text-align: right; padding: 4px 6px; border-bottom: 1px solid #1c2333; }
+.bid { color: var(--bid); } .ask { color: var(--ask); } .muted { color: var(--muted); }
+#walls { list-style: none; padding: 0; margin: 0; font-family: ui-monospace, Menlo, monospace; font-size: 12.5px; }
+#walls li { padding: 4px 0; border-bottom: 1px solid #1c2333; }
+footer { text-align: center; color: var(--muted); font-size: 12px; padding: 16px; }
+
+@media (max-width: 1200px) {
+  .metrics { grid-template-columns: repeat(3, 1fr); }
+  main { grid-template-columns: 1fr; }
+}

--- a/binance-dom/tests/test_analytics.py
+++ b/binance-dom/tests/test_analytics.py
@@ -1,0 +1,111 @@
+import math
+
+import pytest
+
+from dom.analytics import (
+    OrderBook,
+    analyze,
+    detect_walls,
+    imbalance,
+    market_order_fill,
+    microprice,
+    qty_within_bps,
+    spread_bps,
+)
+from dom.client import snap_depth_limit, stream_url
+
+
+def make_book(bids=None, asks=None):
+    bids = bids or [["100.0", "2"], ["99.5", "1"], ["99.0", "1"], ["98.0", "1"], ["97.0", "1"]]
+    asks = asks or [["100.5", "1"], ["101.0", "1"], ["101.5", "1"], ["102.0", "1"], ["103.0", "1"]]
+    return OrderBook.from_binance("testusdt", {"lastUpdateId": 1, "bids": bids, "asks": asks})
+
+
+def test_from_binance_sorts_and_drops_zero_qty():
+    book = OrderBook.from_binance("x", {"bids": [["99", "1"], ["100", "0"], ["100.5", "3"]], "asks": [["102", "1"], ["101", "2"]]})
+    assert book.symbol == "X"
+    assert book.bids == [(100.5, 3.0), (99.0, 1.0)]
+    assert book.asks == [(101.0, 2.0), (102.0, 1.0)]
+
+
+def test_mid_spread_microprice():
+    book = make_book()
+    assert book.mid == 100.25
+    assert spread_bps(book) == pytest.approx(0.5 / 100.25 * 1e4)
+    # bid size 2 vs ask size 1 -> microprice leans towards the ask
+    mp = microprice(book)
+    assert mp == pytest.approx((100.5 * 2 + 100.0 * 1) / 3)
+    assert mp > book.mid
+
+
+def test_imbalance_bounds():
+    assert imbalance(1, 1) == 0
+    assert imbalance(3, 1) == 0.5
+    assert imbalance(0, 5) == -1
+    assert imbalance(0, 0) == 0
+
+
+def test_qty_within_bps():
+    book = make_book()
+    # 100 bps of 100.25 = ~1.0025 -> bids at 100.0 and 99.5 qualify (dist .25, .75); 99.0 is 1.25 away
+    qty, notional = qty_within_bps(book.bids, book.mid, 100, "bid")
+    assert qty == 3
+    assert notional == pytest.approx(100.0 * 2 + 99.5)
+
+
+def test_market_order_fill_walks_book():
+    book = make_book()
+    fill = market_order_fill(book.asks, 150.0)  # 100.5*1 = 100.5, then 49.5 at 101
+    assert fill["fully_filled"] == 1.0
+    assert fill["worst_price"] == 101.0
+    assert fill["filled_qty"] == pytest.approx(1 + 49.5 / 101.0)
+    assert 100.5 < fill["avg_price"] < 101.0
+
+    partial = market_order_fill(book.asks, 1e9)
+    assert partial["fully_filled"] == 0.0
+    assert partial["filled_qty"] == 5
+
+    empty = market_order_fill([], 100)
+    assert empty["avg_price"] is None
+
+
+def test_detect_walls():
+    bids = [(100.0, 1.0), (99.0, 1.0), (98.0, 1.0), (97.0, 10.0), (96.0, 1.0)]
+    walls = detect_walls(bids, 100.5, "bid", ratio=4.0)
+    assert len(walls) == 1
+    assert walls[0].price == 97.0
+    assert walls[0].ratio_to_median == 10.0
+    assert walls[0].distance_bps == pytest.approx((100.5 - 97) / 100.5 * 1e4)
+    assert detect_walls(bids[:3], 100.5, "bid") == []
+    # dust book: 4x median but only a tiny share of the side -> not a wall
+    dust = [(100.0, 0.001), (99.0, 0.001), (98.0, 0.005), (97.0, 100.0), (96.0, 0.001)]
+    assert [w.price for w in detect_walls(dust, 100.5, "bid")] == [97.0]
+
+
+def test_analyze_end_to_end():
+    book = make_book()
+    a = analyze(book, top_n=5)
+    d = a.to_dict()
+    assert d["symbol"] == "TESTUSDT"
+    assert d["imbalance_top"] == pytest.approx(imbalance(6, 5))
+    assert set(d["imbalance_bands"]) == {"5", "10", "25", "50", "100"}
+    assert d["bid_depth_notional"] == pytest.approx(200 + 99.5 + 99 + 98 + 97)
+    assert len(d["cumulative_bids"]) == 5
+    assert d["cumulative_asks"][-1]["cum_qty"] == 5
+    assert d["slippage"]["1000"]["buy_fully_filled"] == 0.0  # only ~508 notional on the ask side
+    assert d["slippage"]["1000"]["buy_slippage_bps"] > 0
+    assert d["signal"] in {"balanced", "mild buy pressure", "strong bid support / buy pressure", "mild sell pressure", "strong ask pressure / sell pressure"}
+    assert all(not math.isnan(v) for v in d["imbalance_bands"].values())
+
+
+def test_analyze_requires_both_sides():
+    with pytest.raises(ValueError):
+        analyze(OrderBook("X", bids=[(1.0, 1.0)], asks=[]))
+
+
+def test_client_helpers():
+    assert snap_depth_limit(7) == 10
+    assert snap_depth_limit(100) == 100
+    assert snap_depth_limit(99999) == 5000
+    assert stream_url("BTCUSDT", levels=20, host="wss://h/ws") == "wss://h/ws/btcusdt@depth20@100ms"
+    assert stream_url("ethusdt", levels=50, speed_ms=1000, host="wss://h/ws") == "wss://h/ws/ethusdt@depth20@1000ms"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

New self-contained project in `binance-dom/`: a live depth-of-market (order book) interpreter for any Binance spot ticker.

- **Backend** (`dom/server.py`, FastAPI): REST endpoints for symbols / depth / analysis / 24h ticker, plus a WebSocket that subscribes to Binance's `@depth{5,10,20}@100ms` stream, runs analytics on every frame and pushes throttled results to the browser. Falls back to REST polling for deeper books (50+ levels) or if the stream is unreachable.
- **Analytics** (`dom/analytics.py`, pure Python, no I/O): mid, spread (bps), microprice + skew, top-N imbalance, imbalance/notional within 5/10/25/50/100 bps bands, market-order slippage for 1K/10K/100K/1M quote sizes, wall detection (ratio-to-median + share-of-side), cumulative depth curves, and a coarse "read" label.
- **Frontend** (`static/`): vanilla JS dashboard with quote-asset filter + searchable ticker picker, live ladder with cumulative bars and wall highlighting, canvas cumulative-depth chart, imbalance-history sparkline, and metric/slippage/wall panels.
- **CLI**: `python -m dom BTCUSDT --limit 100` prints a terminal summary; `--json` dumps the full analysis.
- **Endpoint fallback**: `api.binance.com` is geo-blocked (HTTP 451) in some regions, so the client tries `data-api.binance.vision` first and honours `BINANCE_REST_URLS` / `BINANCE_WS_URLS` overrides (e.g. binance.us).

## Testing

- `pytest`: 9 unit tests covering book parsing, microprice, imbalance, band aggregation, market-order fill walk, wall detection (incl. dust-book false positives), end-to-end `analyze`, and client helpers.
- Live smoke test of REST + WebSocket endpoints against real Binance data (BTCUSDT, ETHUSDT, SOLUSDT); invalid symbol returns 400.
- Browser test: auto-connect, ticker switch, live→poll mode switch, and invalid-ticker error state all verified; no JS runtime errors.

[BTCUSDT dashboard](https://cursor.com/agents/bc-352df16b-3a78-40c7-9f3e-4d2cf4aa8339/artifacts?path=%2Ftmp%2Fdom-btc.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-352df16b-3a78-40c7-9f3e-4d2cf4aa8339?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-352df16b-3a78-40c7-9f3e-4d2cf4aa8339&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

